### PR TITLE
modernize travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,12 @@
-language: cpp
-compiler:
-  - clang
+language: julia
 notifications:
   email: false
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("Decimals")'
-  - julia --code-coverage test/runtests.jl
+julia:
+  - 0.4
+  - nightly
+#script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("Decimals")'
+#  - julia --code-coverage test/runtests.jl
 after_success:
   - julia -e 'cd(Pkg.dir("Decimals")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'


### PR DESCRIPTION
language: julia installs from generic linux nightlies which are usually more up to date than the ppa,
lets you test against more versions of julia, and the default script setting does the right thing
for testing the package (including code coverage info)