### PR TITLE
Modernize and reorganize interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: julia
 notifications:
   email: false
 julia:
-  - 0.4
-  - 0.5
+  - 0.6
   - nightly
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 ## Decimals.jl
 
-[![Build Status](https://travis-ci.org/tinybike/Decimals.jl.svg?branch=master)](https://travis-ci.org/tinybike/Decimals.jl) [![Coverage Status](https://coveralls.io/repos/tinybike/Decimals.jl/badge.svg?branch=master)](https://coveralls.io/r/tinybike/Decimals.jl?branch=master) [![Decimals](http://pkg.julialang.org/badges/Decimals_0.4.svg)](http://pkg.julialang.org/?pkg=Decimals)
+[![Build Status](https://travis-ci.org/tinybike/Decimals.jl.svg?branch=master)](https://travis-ci.org/tinybike/Decimals.jl)
+[![Coverage Status](https://coveralls.io/repos/tinybike/Decimals.jl/badge.svg?branch=master)](https://coveralls.io/r/tinybike/Decimals.jl?branch=master)
+[![Decimals](https://pkg.julialang.org/badges/Decimals_0.6.svg)](https://pkg.julialang.org/?pkg=Decimals)
 
-Basic routines for decimal arithmetic in Julia.  Supports addition, subtraction, negation, multiplication, division, and equality operations; exponentiation coming as soon as I find the time to write it.  This is a pure Julia implementation, so if you are concerned about pure speed, calling `libmpdec` functions directly is likely to be faster.  Tested in Julia 0.3.
+Basic routines for decimal arithmetic in Julia.  Supports addition, subtraction, negation, multiplication, division, and equality operations; exponentiation coming as soon as I find the time to write it.  This is a pure Julia implementation, so if you are concerned about pure speed, calling `libmpdec` functions directly is likely to be faster.  Tested in Julia 0.6.
 
 ### Background
 
@@ -23,7 +25,23 @@ Clearly, this is not okay for fields like finance, where it's important to be ab
 
 #### The Decimal object
 
-You can create Decimal objects from either strings or numbers, using `decimal()`:
+You can parse Decimal objects from strings:
+
+    julia> parse(Decimal, "0.2")
+    Decimals.Decimal(0,2,-1)
+
+    julia> parse(Decimal, "-2.5e6")
+    Decimals.Decimal(1,25,5)
+
+You can construct Decimal objects from other Real numbers:
+
+    julia> Decimal(0.1)
+    Decimal(0,1,-1)
+
+    julia> Decimal(-1003)
+    Decimals.Decimal(1, 1003, 0)
+
+Or can create Decimal objects from either strings or numbers using `decimal`:
 
     julia> decimal("0.2")
     Decimal(0,2,-1)
@@ -99,18 +117,18 @@ Equals (`==` and `isequal`):
     julia> x != decimal("0.1")
     true
 
+Inequality:
+
+    julia> x >= y
+    true
+
+    julia> isless(x, y)
+    false
+
 `==` returns true for Decimal vs. Number comparisons:
 
     julia> x == 0.2
     true
-
-`is` only returns true between two equivalent Decimal objects:
-
-    julia> is(x, decimal("0.2"))
-    true
-
-    julia> is(x, 0.2)
-    false
 
 Rounding:
 
@@ -124,4 +142,4 @@ Rounding:
 
 Unit tests are in `test/`.  To run the tests:
 
-    $ julia test/runtests.jl
+    julia> Pkg.test("Decimals")

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
-
+julia 0.6
+Compat 0.33

--- a/src/Decimals.jl
+++ b/src/Decimals.jl
@@ -1,39 +1,24 @@
 # Pure Julia decimal arithmetic
 # @license MIT
 # @author jack@tinybike.net (Jack Peterson), 7/3/2014
+__precompile__()
 
 module Decimals
-
-    import Core: ===
-    import Base: string, float, ==, +, -, *, /, .*, ./, is
+    import Base: ==, +, -, *, /, <, float, norm, inv
 
     export Decimal,
            decimal,
-           string,
-           float,
-           number,
-           norm,
-           round,
-           isequal,
-           is,
-           isint,
-           inv,
-           +,
-           -,
-           *,
-           /,
-           ==
+           decimal,
+           number
 
     DIGITS = 20
 
     # Numerical value: (-1)^s * c * 10^q
-    immutable Decimal
+    struct Decimal <: Real
         s::Integer  # sign can be 0 (+) or 1 (-)
-        c::BigInt   # coefficient (significand)
+        c::BigInt   # coefficient (significand), must be non-negative
         q::Integer  # exponent
     end
-
-    Decinum = Union{Decimal, Number}
 
     # Convert between Decimal objects, numbers, and strings
     include("decimal.jl")

--- a/src/equals.jl
+++ b/src/equals.jl
@@ -3,15 +3,33 @@
 # equals() now depends on == instead
 # of the other way round.
 function ==(x::Decimal, y::Decimal)
-    a = norm(x)
-    b = norm(y)
+    a = normalize(x)
+    b = normalize(y)
     a.c == b.c && a.q == b.q && a.s == b.s
 end
 
-function ==(x::Number, y::Decimal)
-    decimal(x) == y
-end
+Base.iszero(x::Decimal) = iszero(x.c)
 
-function ==(x::Decimal, y::Number)
-    x == decimal(y)
+function <(x::Decimal, y::Decimal)
+    # return early on zero
+    if iszero(x) && iszero(y)
+        return false
+    end
+
+    signdiff = y.s - x.s
+    if signdiff == 1
+        return false
+    elseif signdiff == -1
+        return true
+    end
+
+    diff = y - x
+
+    farther_from_0 = diff.c > 0 || (iszero(diff.c) && diff.q > 0)
+
+    if diff.s == 1
+        return !farther_from_0
+    else
+        return farther_from_0
+    end
 end

--- a/src/norm.jl
+++ b/src/norm.jl
@@ -1,5 +1,5 @@
 # Normalization: remove trailing zeros in coefficient
-function Base.norm(x::Decimal; rounded::Bool=false)
+function Base.normalize(x::Decimal; rounded::Bool=false)
     p = 0
     if x.c != 0
         while x.c % 10^(p+1) == 0
@@ -14,3 +14,5 @@ function Base.norm(x::Decimal; rounded::Bool=false)
         round(Decimal(x.s, abs(c), q), DIGITS; normal=true)
     end
 end
+
+@deprecate norm(x::Decimal; kwargs...) normalize(x; kwargs...)

--- a/src/round.jl
+++ b/src/round.jl
@@ -2,10 +2,10 @@
 function Base.round(x::Decimal, dpts::Int=0; normal::Bool=false)
     shift = BigInt(dpts) + x.q
     if shift > BigInt(0) || shift < x.q
-        (normal) ? x : norm(x, rounded=true)
+        (normal) ? x : normalize(x, rounded=true)
     else
     c = Base.round(x.c / BigInt(10)^(-shift))
     d = Decimal(x.s, BigInt(c), x.q - shift)
-    (normal) ? d : norm(d, rounded=true)
+    (normal) ? d : normalize(d, rounded=true)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,17 +1,23 @@
 using Decimals
-using Base.Test
+using Compat.Test
 
-tests = ["constructor",
-         "decimal", 
-         "norm",
-         "arithmetic",
-         "equals",
-         "round"]
+@testset "Decimals" begin
 
-println("Running tests:")
+global d = [
+    Decimal(0, 2, -1)
+    Decimal(0, 1, -1)
+    Decimal(0, 100, -4)
+    Decimal(0, 1512, -2)
+    Decimal(1, 3, -2)
+    Decimal(1, 4, -6)
+]
 
-for t in tests
-    tfile = string("test_", t, ".jl")
-    println(" * $(t) ...")
-    include(tfile)
+include("test_constructor.jl")
+include("test_decimal.jl")
+include("test_norm.jl")
+include("test_arithmetic.jl")
+include("test_equals.jl")
+include("test_round.jl")
+include("test_deprecated.jl")
+
 end

--- a/test/test_arithmetic.jl
+++ b/test/test_arithmetic.jl
@@ -1,49 +1,57 @@
 using Decimals
-using Base.Test
+using Compat.Test
 
-# Addition
-@test decimal(0.1) + 0.2 == 0.1 + decimal(0.2) == decimal(0.1) + decimal(0.2) == decimal(0.3)
-@test decimal([0.1 0.2]) + [0.3 0.1] == decimal([0.4 0.3])
-@test decimal(2147483646) + decimal(1) == decimal(2147483647)
-@test Decimal(1,3,-2) + decimal("0.2523410412138103") == Decimal(0,2223410412138103,-16)
+@testset "Arithmetic" begin
 
-# Subtraction
-@test decimal(0.3) - 0.1 == 0.3 - decimal(0.1)
-@test 0.3 - decimal(0.1) == decimal(0.3) - decimal(0.1)
-@test decimal(0.3) - decimal(0.1) == decimal(0.2)
-@test decimal([0.3 0.1]) - [0.1 0.5] == decimal([0.2 -0.4])
+@testset "Addition" begin
+    @test Decimal(0.1) + 0.2 == 0.1 + Decimal(0.2) == Decimal(0.1) + Decimal(0.2) == Decimal(0.3)
+    @test Decimal.([0.1 0.2]) .+ [0.3 0.1] == Decimal.([0.4 0.3])
+    @test Decimal(2147483646) + Decimal(1) == Decimal(2147483647)
+    @test Decimal(1,3,-2) + parse(Decimal, "0.2523410412138103") == Decimal(0,2223410412138103,-16)
+end
 
-# Negation
-@test -decimal([0.3 0.2]) == [-decimal(0.3) -decimal(0.2)]
+@testset "Subtraction" begin
+    @test Decimal(0.3) - 0.1 == 0.3 - Decimal(0.1)
+    @test 0.3 - Decimal(0.1) == Decimal(0.3) - Decimal(0.1)
+    @test Decimal(0.3) - Decimal(0.1) == Decimal(0.2)
+    @test Decimal.([0.3 0.1]) .- [0.1 0.5] == Decimal.([0.2 -0.4])
+end
 
-# Multiplication
-@test decimal(12.21) * decimal(2.12) == Decimal(0,258852,-4)
-@test decimal(12.2112543) * decimal(2.121352) == Decimal(0,259043687318136,-13)
-@test decimal(0.2) * 0.1 == 0.2 * decimal(0.1)
-@test 0.2 * decimal(0.1) == decimal(0.02)
-@test decimal(12.34) * 0.1234 == 12.34 * decimal(0.1234)
-@test 12.34 * decimal(0.1234) == decimal(1.522756)
-@test decimal(0.21084210) * -2 == -2 * decimal(0.21084210)
-@test -2 * decimal(0.21084210) == decimal(-0.4216842)
-# @test decimal([0.1 0.2]) .* [3 2] == [Decimal(0,3,-1) Decimal(0,4,-1)]
-# @test decimal([0.1 0.2]) .* [1.2 2.1] == [Decimal(0,12,-2) Decimal(0,42,-2)]
-# @test decimal([0.1,0.2]) * [1.2 2.1] == [Decimal(0,12,-2) Decimal(0,21,-2); Decimal(0,24,-2) Decimal(0,42,-2)]
-@test Decimal(0, 2, -1) * 0.0 == decimal(0)
-@test decimal([0.3, 0.6]) .* 5 == [decimal(0.3)*5, decimal(0.6)*5]
+@testset "Negation" begin
+    @test -Decimal.([0.3 0.2]) == [-Decimal(0.3) -Decimal(0.2)]
+    @test -Decimal(0.3) == zero(Decimal) - Decimal(0.3)
+end
 
-# Inversion
-@test inv(Decimal(0, 1, -1)) == Decimal(0, 1, 1)
-@test inv(Decimal(0, 1, 1)) == Decimal(0, 1, -1)
-@test inv(Decimal(1, 2, -1)) == Decimal(1, 5, 0)
-@test inv(Decimal(1, 5, 0)) == Decimal(1, 2, -1)
-@test inv(Decimal(0, 2, -2)) == Decimal(0, 5, 1)
-@test inv(Decimal(0, 5, 1)) == Decimal(0, 2, -2)
-@test inv(Decimal(1, 4, -1)) == Decimal(1, 25, -1)
-@test inv(Decimal(1, 25, -1)) == Decimal(1, 4, -1)
-@test inv(d) == map(inv, d)
+@testset "Multiplication" begin
+    @test Decimal(12.21) * Decimal(2.12) == Decimal(0,258852,-4)
+    @test Decimal(12.2112543) * Decimal(2.121352) == Decimal(0,259043687318136,-13)
+    @test Decimal(0.2) * 0.1 == 0.2 * Decimal(0.1)
+    @test 0.2 * Decimal(0.1) == Decimal(0.02)
+    @test Decimal(12.34) * 0.1234 == 12.34 * Decimal(0.1234)
+    @test 12.34 * Decimal(0.1234) == Decimal(1.522756)
+    @test Decimal(0.21084210) * -2 == -2 * Decimal(0.21084210)
+    @test -2 * Decimal(0.21084210) == Decimal(-0.4216842)
+    @test Decimal(0, 2, -1) * 0.0 == zero(Decimal)
+    @test Decimal.([0.3, 0.6]) .* 5 == [Decimal(0.3)*5, Decimal(0.6)*5]
+    @test one(Decimal) * 1 == Decimal(0, 1, 0)
+end
 
-# Division
-@test decimal(0.2) / decimal(0.1) == decimal(2)
-@test decimal(0.3) / decimal(0.1) == Decimal(0,3,0)
-@test [decimal(0.3)/decimal(0.1), decimal(0.6)/decimal(0.1)] == [decimal(0.3), decimal(0.6)] ./ decimal(0.1)
-@test [decimal(0.3)/0.1, decimal(0.6)/0.1] == [decimal(0.3), decimal(0.6)] ./ 0.1
+@testset "Inversion" begin
+    @test inv(Decimal(0, 1, -1)) == Decimal(0, 1, 1)
+    @test inv(Decimal(0, 1, 1)) == Decimal(0, 1, -1)
+    @test inv(Decimal(1, 2, -1)) == Decimal(1, 5, 0)
+    @test inv(Decimal(1, 5, 0)) == Decimal(1, 2, -1)
+    @test inv(Decimal(0, 2, -2)) == Decimal(0, 5, 1)
+    @test inv(Decimal(0, 5, 1)) == Decimal(0, 2, -2)
+    @test inv(Decimal(1, 4, -1)) == Decimal(1, 25, -1)
+    @test inv(Decimal(1, 25, -1)) == Decimal(1, 4, -1)
+end
+
+@testset "Division" begin
+    @test Decimal(0.2) / Decimal(0.1) == Decimal(2)
+    @test Decimal(0.3) / Decimal(0.1) == Decimal(0,3,0)
+    @test [Decimal(0.3) / Decimal(0.1), Decimal(0.6) / Decimal(0.1)] == [Decimal(0.3), Decimal(0.6)] ./ Decimal(0.1)
+    @test [Decimal(0.3) / 0.1, Decimal(0.6) / 0.1] == [Decimal(0.3), Decimal(0.6)] ./ 0.1
+end
+
+end

--- a/test/test_constructor.jl
+++ b/test/test_constructor.jl
@@ -1,14 +1,8 @@
 using Decimals
-using Base.Test
+using Compat.Test
 
-# Decimal constructor
-d = [
-    Decimal(0, 2, -1),
-    Decimal(0, 1, -1),
-    Decimal(0, 100, -4),
-    Decimal(0, 1512, -2),
-    Decimal(1, 3, -2),
-    Decimal(1, 4, -6),
-]
+@testset "Decimal constructor" begin
 
 @test isa(d, Array{Decimal,1})
+
+end

--- a/test/test_decimal.jl
+++ b/test/test_decimal.jl
@@ -1,66 +1,82 @@
 using Decimals
-using Base.Test
+using Compat.Test
 
-# Number/string to decimal conversions
-@test decimal("0.01") == decimal(0.01) == Decimal(0, 1, -2)
-@test decimal(".001") == decimal(.001) == Decimal(0, 1, -3)
-@test decimal("15.23") == decimal(15.23) == Decimal(0, 1523, -2)
-@test decimal("543") == decimal(543) == Decimal(0, 543, 0)
-@test decimal("-345") == decimal(-345) == Decimal(1, 345, 0)
-@test decimal("000123") == decimal(000123) == Decimal(0, 123, 0)
-@test decimal("-00032") == decimal(-00032) == Decimal(1, 32, 0)
-@test decimal("200100") == decimal(200100) == Decimal(0, 2001, 2)
-@test decimal("-.123") == decimal(-.123) == Decimal(1, 123, -3)
-@test decimal("1.23000") == decimal(1.23000) == Decimal(0, 123, -2)
-@test decimal("4734.612") == decimal(4734.612) == Decimal(0, 4734612, -3)
-@test decimal("541724.2") == decimal(541724.2) == Decimal(0,5417242,-1)
-@test decimal("2.5e6") == decimal(2.5e6) == Decimal(0, 25, 5)
-@test decimal("2.385350e8") == decimal(2.385350e8) == Decimal(0, 238535, 3)
-@test decimal("12.3e-4") == decimal(12.3e-4) == Decimal(0, 123, -5)
+@testset "Conversions" begin
 
-@test decimal("-12.3e4") == decimal(-12.3e4) == Decimal(1, 123, 3)
+@testset "String/Number to Decimal" begin
+    @testset "Direct" begin
+        @test parse(Decimal, "0.01") == Decimal(0.01) == Decimal(0, 1, -2)
+        @test parse(Decimal, ".001") == Decimal(.001) == Decimal(0, 1, -3)
+        @test parse(Decimal, "15.23") == Decimal(15.23) == Decimal(0, 1523, -2)
+        @test parse(Decimal, "543") == Decimal(543) == Decimal(0, 543, 0)
+        @test parse(Decimal, "-345") == Decimal(-345) == Decimal(1, 345, 0)
+        @test parse(Decimal, "000123") == Decimal(000123) == Decimal(0, 123, 0)
+        @test parse(Decimal, "-00032") == Decimal(-00032) == Decimal(1, 32, 0)
+        @test parse(Decimal, "200100") == Decimal(200100) == Decimal(0, 2001, 2)
+        @test parse(Decimal, "-.123") == Decimal(-.123) == Decimal(1, 123, -3)
+        @test parse(Decimal, "1.23000") == Decimal(1.23000) == Decimal(0, 123, -2)
+        @test parse(Decimal, "4734.612") == Decimal(4734.612) == Decimal(0, 4734612, -3)
+        @test parse(Decimal, "541724.2") == Decimal(541724.2) == Decimal(0,5417242,-1)
+        @test parse(Decimal, "2.5e6") == Decimal(2.5e6) == Decimal(0, 25, 5)
+        @test parse(Decimal, "2.385350e8") == Decimal(2.385350e8) == Decimal(0, 238535, 3)
+        @test parse(Decimal, "12.3e-4") == Decimal(12.3e-4) == Decimal(0, 123, -5)
 
-@test decimal("-12.3e-4") == decimal(-12.3e-4) == Decimal(1, 123, -5)
+        @test parse(Decimal, "-12.3e4") == Decimal(-12.3e4) == Decimal(1, 123, 3)
 
-@test decimal("0.1234567891") == decimal(0.1234567891) == Decimal(0,1234567891, -10)
-@test decimal("0.12345678912") == decimal(0.12345678912) == Decimal(0,12345678912, -11)
+        @test parse(Decimal, "-12.3e-4") == Decimal(-12.3e-4) == Decimal(1, 123, -5)
 
-# Array-to-decimal conversion
-@test decimal([0.1 0.2 0.3]) == [decimal(0.1) decimal(0.2) decimal(0.3)]
+        @test parse(Decimal, "0.1234567891") == Decimal(0.1234567891) == Decimal(0,1234567891, -10)
+        @test parse(Decimal, "0.12345678912") == Decimal(0.12345678912) == Decimal(0,12345678912, -11)
+    end
 
-# Decimal-to-string conversions
-@test string(Decimal(0, 1, -2)) == "0.01"
-@test string(Decimal(0, 1, -3)) == "0.001"
-@test string(Decimal(0, 1523, -2)) == "15.23"
-@test string(Decimal(0, 543, 0)) == "543"
-@test string(Decimal(1, 345, 0)) == "-345"
-@test string(Decimal(0, 123, 0)) == "123"
-@test string(Decimal(1, 32, 0)) == "-32"
-@test string(Decimal(0, 2001, 2)) == "200100"
-@test string(Decimal(1, 123, -3)) == "-0.123"
-@test string(Decimal(0, 123, -2)) == "1.23"
+    @testset "Using `decimal`" begin
+        @test decimal("1.0") == Decimal(0, 1, 0)
+        @test decimal(8.1) == Decimal(0, 81, -1)
+        @test decimal.(Float64.(d)) == d
+    end
+end
 
-# Decimal-to-number conversions
-@test float(Decimal(0, 1, -2)) == 0.01
-@test float(Decimal(0, 1, -3)) == 0.001
-@test float(Decimal(0, 1523, -2)) == 15.23
-@test float(Decimal(0, 543, 0)) == 543
-@test float(Decimal(1, 345, 0)) == -345
-@test float(Decimal(0, 123, 0)) == 123
-@test float(Decimal(1, 32, 0)) == -32
-@test float(Decimal(0, 2001, 2)) == 200100
-@test float(Decimal(1, 123, -3)) == -0.123
-@test float(Decimal(0, 123, -2)) == 1.23
-@test number(Decimal(0, 1, -2)) == 0.01
-@test number(Decimal(0, 1, -3)) == 0.001
-@test number(Decimal(0, 1523, -2)) == 15.23
-@test number(Decimal(0, 543, 0)) == 543
-@test number(Decimal(1, 345, 0)) == -345
-@test number(Decimal(0, 123, 0)) == 123
-@test number(Decimal(1, 32, 0)) == -32
-@test number(Decimal(0, 2001, 2)) == 200100
-@test number(Decimal(1, 123, -3)) == -0.123
-@test number(Decimal(0, 123, -2)) == 1.23
-@test string(float(Decimal(0, 543, 0))) == "543.0"
-@test string(number(Decimal(0, 543, 0))) == "543"
-@test string(number(Decimal(0, 543, -1))) == "54.3"
+@testset "Array{<:Number} to Array{Decimal}" begin
+    @test Decimal.([0.1 0.2 0.3]) == [Decimal(0.1) Decimal(0.2) Decimal(0.3)]
+end
+
+@testset "Decimal to String" begin
+    @test string(Decimal(0, 1, -2)) == "0.01"
+    @test string(Decimal(0, 1, -3)) == "0.001"
+    @test string(Decimal(0, 1523, -2)) == "15.23"
+    @test string(Decimal(0, 543, 0)) == "543"
+    @test string(Decimal(1, 345, 0)) == "-345"
+    @test string(Decimal(0, 123, 0)) == "123"
+    @test string(Decimal(1, 32, 0)) == "-32"
+    @test string(Decimal(0, 2001, 2)) == "200100"
+    @test string(Decimal(1, 123, -3)) == "-0.123"
+    @test string(Decimal(0, 123, -2)) == "1.23"
+end
+
+@testset "Decimal to Number" begin
+    @test Float32(Decimal(0, 1, -2)) == 0.01f0
+    @test Float64(Decimal(0, 1, -3)) == 0.001
+    @test Float64(Decimal(0, 1523, -2)) == 15.23
+    @test UInt(Decimal(0, 543, 0)) == 543
+    @test Int(Decimal(1, 345, 0)) == -345
+    @test Int32(Decimal(0, 123, 0)) == 123
+    @test Int8(Decimal(1, 32, 0)) == -32
+    @test BigInt(Decimal(0, 2001, 2)) == 200100
+    @test BigFloat(Decimal(1, 123, -3)) == big"-0.123"
+    @test Float64(Decimal(0, 123, -2)) == 1.23
+    @test number(Decimal(0, 1, -2)) == 0.01
+    @test number(Decimal(0, 1, -3)) == 0.001
+    @test number(Decimal(0, 1523, -2)) == 15.23
+    @test number(Decimal(0, 543, 0)) == 543
+    @test number(Decimal(1, 345, 0)) == -345
+    @test number(Decimal(0, 123, 0)) == 123
+    @test number(Decimal(1, 32, 0)) == -32
+    @test number(Decimal(0, 2001, 2)) == 200100
+    @test number(Decimal(1, 123, -3)) == -0.123
+    @test number(Decimal(0, 123, -2)) == 1.23
+    @test string(Float64(Decimal(0, 543, 0))) == "543.0"
+    @test string(number(Decimal(0, 543, 0))) == "543"
+    @test string(number(Decimal(0, 543, -1))) == "54.3"
+end
+
+end

--- a/test/test_deprecated.jl
+++ b/test/test_deprecated.jl
@@ -1,0 +1,24 @@
+using Decimals
+using Compat.Test
+
+@testset "Deprecated Functions" begin
+    info("The following deprecation warnings are expected")
+
+    @test inv(d) == map(inv, d)
+
+    @test 1 + d == 1 .+ d
+    @test d + 3.0 == d .+ 3.0
+    @test 8.0 - d == 8.0 .- d
+    @test d - 10 == d .- 10
+    @test [1] + d == [1] .+ d
+    @test d + [3.0] == d .+ [3.0]
+    @test [8.0] - d == [8.0] .- d
+    @test d - [10] == d .- [10]
+
+    @test number(d) == number.(d)
+    @test all(isint.([0, -102, 0x99]))
+    @test !any(isint.(float.(d)))
+    @test !any(isint.(string.(d)))
+
+    @test decimal(float(d)) == d
+end

--- a/test/test_equals.jl
+++ b/test/test_equals.jl
@@ -1,30 +1,35 @@
 using Decimals
-using Base.Test
+using Compat.Test
 
-# Equality
-@test isequal(Decimal(0, 2, -3), Decimal(0, 2, -3))
-@test ~isequal(Decimal(0, 2, -3), Decimal(0, 2, 3))
-@test isequal(Decimal(0, 2, -3), 0.002)
-@test isequal(Decimal(1, 2, 0), -2)
-@test ~isequal(Decimal(1, 2, 0), 2)
+@testset "Equality" begin
 
-@test isequal(0.1, 0.1)
-@test isequal(2, 2)
+@testset "isequal" begin
+    @test isequal(Decimal(0, 2, -3), Decimal(0, 2, -3))
+    @test ~isequal(Decimal(0, 2, -3), Decimal(0, 2, 3))
+    @test isequal(Decimal(0, 2, -3), 0.002)
+    @test isequal(Decimal(1, 2, 0), -2)
+    @test ~isequal(Decimal(1, 2, 0), 2)
+end
 
-@test Decimal(0, 2, -3) == Decimal(0, 2, -3)
-@test Decimal(0, 2, -3) != Decimal(0, 2, 3)
-@test Decimal(0, 2, -3) == 0.002
+@testset "==" begin
+    @test Decimal(0, 2, -3) == Decimal(0, 2, -3)
+    @test Decimal(0, 2, -3) != Decimal(0, 2, 3)
+    @test Decimal(0, 2, -3) == 0.002
 
-@test -2 == Decimal(1, 2, 0)
-@test 2 != Decimal(1, 2, 0)
+    @test -2 == Decimal(1, 2, 0)
+    @test 2 != Decimal(1, 2, 0)
 
-@test Decimal(1, 2, 0) == -2
-@test Decimal(1, 2, 0) != 2
+    @test Decimal(1, 2, 0) == -2
+    @test Decimal(1, 2, 0) != 2
+end
 
-@test 0.1 == 0.1
-@test 2 == 2
+@testset "<" begin
+    @test Decimal(1, 1, 1) < Decimal(0, 1, 1)
+    @test !(Decimal(0, 1, 1) < Decimal(1, 1, 1))
+    @test Decimal(1, 1, 1) < Decimal(1, 0, 1)
+    @test !(Decimal(1, 0, 1) < Decimal(1, 1, 1))
+    @test Decimal(0, 2, -3) < Decimal(0, 2, 3)
+    @test !(Decimal(0, 2, 3) < Decimal(0, 2, -3))
+end
 
-# Triple equals
-# Is there a way to redefine === in Julia 4.x?
-# @test Decimal(0, 2, -3) === Decimal(0, 2, -3)
-# @test decimal("0.2") === 0.2
+end

--- a/test/test_norm.jl
+++ b/test/test_norm.jl
@@ -1,12 +1,15 @@
 using Decimals
-using Base.Test
+using Compat.Test
 
-# Normalization
+@testset "Normalization" begin
+
 @test Decimal(1, 151100, -4) == Decimal(1, 1511, -2)
 @test Decimal(0, 100100, -5) == Decimal(0, 1001, -3)
-@test norm(Decimal(1, 151100, -4)) == Decimal(1, 1511, -2)
-@test norm(Decimal(0, 100100, -5)) == Decimal(0, 1001, -3)
-@test decimal("3.0") == Decimal(0, 3, 0)
-@test decimal("3.0") == Decimal(0, 30, -1)
-@test decimal("3.1400") == Decimal(0, 314, -2)
-@test decimal("1234") == Decimal(0, 1234, 0)
+@test normalize(Decimal(1, 151100, -4)) == Decimal(1, 1511, -2)
+@test normalize(Decimal(0, 100100, -5)) == Decimal(0, 1001, -3)
+@test parse(Decimal, "3.0") == Decimal(0, 3, 0)
+@test parse(Decimal, "3.0") == Decimal(0, 30, -1)
+@test parse(Decimal, "3.1400") == Decimal(0, 314, -2)
+@test parse(Decimal, "1234") == Decimal(0, 1234, 0)
+
+end

--- a/test/test_round.jl
+++ b/test/test_round.jl
@@ -1,18 +1,19 @@
 using Decimals
-using Base.Test
+using Compat.Test
 
-# Rounding
-@test round(decimal(7.123456), 0) == decimal(7)
-@test round(decimal(7.123456), 2) == decimal(7.12)
-@test round(decimal(7.123456), 3) == decimal(7.123)
-@test round(decimal(7.123456), 5) == decimal(7.12346)
-@test round(decimal(7.123456), 6) == decimal(7.123456)
+@testset "Rounding" begin
+
+@test round(Decimal(7.123456), 0) == Decimal(7)
+@test round(Decimal(7.123456), 2) == Decimal(7.12)
+@test round(Decimal(7.123456), 3) == Decimal(7.123)
+@test round(Decimal(7.123456), 5) == Decimal(7.12346)
+@test round(Decimal(7.123456), 6) == Decimal(7.123456)
 
 @test round(0.123, 1) == 0.1
-@test round([0.1111 0.2222 0.8888], 2) == [0.11 0.22 0.89]
+@test round.([0.1111 0.2222 0.8888], 2) == [0.11 0.22 0.89]
 
 function tet()
-    a = decimal("1.0000001")
+    a = parse(Decimal, "1.0000001")
     for i = 1:27
         a *= a
     end
@@ -21,3 +22,5 @@ end
 
 # set DIGITS = 20 (aaljuffali's example)
 @test tet() == Decimal(0, 67453047074102193157641340, -20)
+
+end


### PR DESCRIPTION
This does a lot of things, and you may not want all of them, but I'm willing to change anything you object to. I do think this would make a good next version. 

Highlights:
- works on 0.6 and 0.7 with no deprecation warnings, and drops support for earlier versions
- adds `parse`
- adds conversions to specific number types
- migrates `decimal` functionality to appropriate functions according to convention and makes `decimal` a wrapper for those
- deprecates methods whose Base analogues have been deprecated, including functions which operate on arrays
- adds inequality operators (they follow from `<` and `==`)
- uses promotion machinery instead of defining methods taking `Number`
- uses `@testsets` for tests, improving test output

Please let me know what you think! :)