### PR TITLE
Fix promotion stack overflows with Base Big* types

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,5 +1,9 @@
 Base.promote_rule(::Type{Decimal}, ::Type{<:Real}) = Decimal
 
+# override definitions in Base
+Base.promote_rule(::Type{BigFloat}, ::Type{Decimal}) = Decimal
+Base.promote_rule(::Type{BigInt}, ::Type{Decimal}) = Decimal
+
 # Addition
 # To add, convert both decimals to the same exponent.
 # (If the exponents are different, use the smaller exponent

--- a/test/test_equals.jl
+++ b/test/test_equals.jl
@@ -21,6 +21,14 @@ end
 
     @test Decimal(1, 2, 0) == -2
     @test Decimal(1, 2, 0) != 2
+
+    bf_pi = BigFloat(pi)
+    @test Decimal(bf_pi) == bf_pi
+    @test bf_pi == Decimal(bf_pi)
+
+    bi = big"4608230166434464229556241992703"
+    @test Decimal(bi) == bi
+    @test bi == Decimal(bi)
 end
 
 @testset "<" begin


### PR DESCRIPTION
After my previous changes, equality checks with Base Big* types embarrassingly stack-overflowed due to both Decimal and BigFloat/BigInt assuming they were the biggest possible type. With a couple additional promotion rules, that is now fixed.