### PR TITLE
Updates for Julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ notifications:
   email: false
 julia:
   - 0.6
+  - 0.7
   - nightly
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Inequality:
 
 Rounding:
 
-    julia> round(decimal(3.1415), 2)
+    julia> round(decimal(3.1415), digits=2)
     Decimal(0,314,-2)
 
     julia> string(ans)

--- a/src/Decimals.jl
+++ b/src/Decimals.jl
@@ -4,10 +4,15 @@
 __precompile__()
 
 module Decimals
-    import Base: ==, +, -, *, /, <, float, norm, inv, round
+    import Base: ==, +, -, *, /, <, float, inv, round
+
+    if VERSION < v"0.7.0-DEV.3449"
+        import Base: normalize
+    else
+        export normalize
+    end
 
     export Decimal,
-           decimal,
            decimal,
            number
 

--- a/src/Decimals.jl
+++ b/src/Decimals.jl
@@ -4,14 +4,14 @@
 __precompile__()
 
 module Decimals
-    import Base: ==, +, -, *, /, <, float, norm, inv
+    import Base: ==, +, -, *, /, <, float, norm, inv, round
 
     export Decimal,
            decimal,
            decimal,
            number
 
-    DIGITS = 20
+    const DIGITS = 20
 
     # Numerical value: (-1)^s * c * 10^q
     struct Decimal <: Real

--- a/src/decimal.jl
+++ b/src/decimal.jl
@@ -68,7 +68,7 @@ Base.one(::Type{Decimal}) = Decimal(0,1,0)
 
 # Convert a decimal to a float
 @deprecate float(x::Decimal) Float64(x)
-@deprecate float(x::Array{Decimal}) map(float, x)
+@deprecate float(x::Array{Decimal}) map(Float64, x)
 
 # convert a decimal to any subtype of Real
 (::Type{T})(x::Decimal) where {T<:Real} = parse(T, string(x))
@@ -83,4 +83,4 @@ end
 # Check if integer
 @deprecate isint(x::Integer) isinteger(x)
 @deprecate isint(x::AbstractFloat) isinteger(x)
-@deprecate isint(x::AbstractString) isinteger(float(x))
+@deprecate isint(x::AbstractString) isinteger(parse(Float64, x))

--- a/src/norm.jl
+++ b/src/norm.jl
@@ -11,7 +11,7 @@ function Base.normalize(x::Decimal; rounded::Bool=false)
     if rounded
         Decimal(x.s, abs(c), q)
     else
-        round(Decimal(x.s, abs(c), q), DIGITS; normal=true)
+        round(Decimal(x.s, abs(c), q), digits=DIGITS, normal=true)
     end
 end
 

--- a/src/norm.jl
+++ b/src/norm.jl
@@ -1,5 +1,5 @@
 # Normalization: remove trailing zeros in coefficient
-function Base.normalize(x::Decimal; rounded::Bool=false)
+function normalize(x::Decimal; rounded::Bool=false)
     p = 0
     if x.c != 0
         while x.c % 10^(p+1) == 0

--- a/src/round.jl
+++ b/src/round.jl
@@ -1,11 +1,13 @@
 # Rounding
-function Base.round(x::Decimal, dpts::Int=0; normal::Bool=false)
-    shift = BigInt(dpts) + x.q
+function round(x::Decimal; digits::Int=0, normal::Bool=false)
+    shift = BigInt(digits) + x.q
     if shift > BigInt(0) || shift < x.q
         (normal) ? x : normalize(x, rounded=true)
     else
-    c = Base.round(x.c / BigInt(10)^(-shift))
-    d = Decimal(x.s, BigInt(c), x.q - shift)
-    (normal) ? d : normalize(d, rounded=true)
+        c = Base.round(x.c / BigInt(10)^(-shift))
+        d = Decimal(x.s, BigInt(c), x.q - shift)
+        (normal) ? d : normalize(d, rounded=true)
     end
 end
+
+@deprecate round(x::Decimal, dpts::Int; normal::Bool=false) round(x, digits=dpts, normal=normal)

--- a/test/test_round.jl
+++ b/test/test_round.jl
@@ -3,14 +3,13 @@ using Compat.Test
 
 @testset "Rounding" begin
 
-@test round(Decimal(7.123456), 0) == Decimal(7)
-@test round(Decimal(7.123456), 2) == Decimal(7.12)
-@test round(Decimal(7.123456), 3) == Decimal(7.123)
-@test round(Decimal(7.123456), 5) == Decimal(7.12346)
-@test round(Decimal(7.123456), 6) == Decimal(7.123456)
+@test round(Decimal(7.123456), digits=0) == Decimal(7)
+@test round(Decimal(7.123456), digits=2) == Decimal(7.12)
+@test round(Decimal(7.123456), digits=3) == Decimal(7.123)
+@test round(Decimal(7.123456), digits=5) == Decimal(7.12346)
+@test round(Decimal(7.123456), digits=6) == Decimal(7.123456)
 
-@test round(0.123, 1) == 0.1
-@test round.([0.1111 0.2222 0.8888], 2) == [0.11 0.22 0.89]
+@test round.(Decimal.([0.1111, 0.2222, 0.8888]), digits=2) == Decimal.([0.11, 0.22, 0.89])
 
 function tet()
     a = parse(Decimal, "1.0000001")


### PR DESCRIPTION
This PR makes a few changes necessary for Julia 0.7. I've separated them into logically distinct commits.

1. Only extend `Base.normalize` when it's actually in Base.

   In Julia 0.7, `normalize` has been moved to the LinearAlgebra standard library package. To avoid conflating the meaning of normalization with that used in linear algebra, this change simply stops extending `normalize` from Base for versions after linear algebra functionality was separated from Base. On such versions, `normalize` is instead exported from this package.

   The downside to this is that if a user loads both Decimals and LinearAlgebra, they'll get a warning and have to qualify all calls to `normalize` with the appropriate module, i.e. `Decimals.normalize` and `LinearAlgebra.normalize`.

2. Make `digits` a keyword argument to `round`.

   In Julia 0.7, the `digits` positional argument to `round` was deprecated in favor of a `digits=` keyword argument. This introduces a similar change here.

3. Fix a couple of deprecation targets.

   For some of the existing deprecations, if a user fixed them according to the warning message emitted here, the resulting code would emit a different deprecation warning. :smile: 

4. Add 0.7 to the testing matrix.

   While `nightly` is indeed currently 0.7, `0.7` on Travis uses 0.7.0-beta whereas `nightly` uses builds from the master branch.

I think there's more words here than there are changes to the code, but hopefully I've explained the rationale and tradeoffs sufficiently.